### PR TITLE
Remove `pull_request` Trigger from Build and Deploy Workflow

### DIFF
--- a/.github/workflows/build-deploy-v1.yml
+++ b/.github/workflows/build-deploy-v1.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
   workflow_dispatch:
   schedule:
     - cron: "0 0 * * *"


### PR DESCRIPTION
## Description

This pull request removes the `pull_request` trigger from the build-deploy workflow. This change ensures that the workflow only runs when specific conditions are met, rather than triggering on every pull request event.

## Checklist

- [x] All unit tests have passed.

## Related Issues

N/A

## Additional Notes

N/A